### PR TITLE
Support for `ignore_unfixed` param & deprecation of docker build step

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@
 
 - [About Accuknox](https://www.accuknox.com/)
 
-| Input Values       | Description                                                                                            | Optional/Required | Default Values                         |
-| ------------------ | ------------------------------------------------------------------------------------------------------ | ----------------- | -------------------------------------- |
-| dockerfile_context | The context of the Dockerfile to use for building the image.                                           | Optional          | Dockerfile                             |
-| endpoint           | The URL of the CSPM panel to push the scan results to.                                                 | Optional          | `cspm.demo.accuknox.com`               |
-| token              | The token for authenticating with the CSPM panel.                                                      | Required          | -                                      |
-| tenant_id          | The ID of the tenant associated with the CSPM panel.                                                   | Required          | -                                      |
-| repository_name    | Docker image repository name.                                                                          | Required          | -                                      |
-| tag                | Add version tag to the repository.                                                                     | Optional          | `${{ github.run_id }}`                 |
-| severity           | Allows selection of severity level for the scan. Options include UNKNOWN, LOW, MEDIUM, HIGH, CRITICAL. | Optional          | `UNKNOWN, LOW, MEDIUM, HIGH, CRITICAL` |
-| exit_code          | Specifies pipeline behavior upon detecting specified severity level. '0' (continue) or '1' (halt).     | Optional          | 0                                      |
-| label              | The label created in AccuKnox SaaS for associating scan results.                                       | Required          | -                                      |
+| Input Values    | Description                                                                                            | Optional/Required | Default Values                         |
+|-----------------|--------------------------------------------------------------------------------------------------------|-------------------|----------------------------------------|
+| endpoint        | The URL of the CSPM panel to push the scan results to.                                                 | Optional          | `cspm.demo.accuknox.com`               |
+| token           | The token for authenticating with the CSPM panel.                                                      | Required          | -                                      |
+| tenant_id       | The ID of the tenant associated with the CSPM panel.                                                   | Required          | -                                      |
+| repository_name | Docker image repository name.                                                                          | Required          | -                                      |
+| tag             | Add version tag to the repository.                                                                     | Optional          | `${{ github.run_id }}`                 |
+| severity        | Allows selection of severity level for the scan. Options include UNKNOWN, LOW, MEDIUM, HIGH, CRITICAL. | Optional          | `UNKNOWN, LOW, MEDIUM, HIGH, CRITICAL` |
+| exit_code       | Specifies pipeline behavior upon detecting specified severity level. '0' (continue) or '1' (halt).     | Optional          | 0                                      |
+| ignore_unfixed  | Ignore vulnerabilities for which a fix isn't available yet.                                            | Optional          | false                                  |
+| label           | The label created in AccuKnox SaaS for associating scan results.                                       | Required          | -                                      |
 
 ## Usage
 
@@ -49,7 +49,7 @@ Click on Generate:
           tag:                             #Optional
           exit_code:                       #Optional
           severity:                        #Optional
-          dockerfile_context:              #Optional
+          ignore_unfixed:                  #Optional
 ```
 
 ## Minimalist Sample Configuration

--- a/action.yaml
+++ b/action.yaml
@@ -31,6 +31,10 @@ inputs:
     description: "Values '0' and '1' are accepted. '0' is the default value, which indicates that the pipeline will not be halted if the specified severity is found, while '1' indicates that the pipeline will stop if a specified severity level is detected."
     required: false
     default: "0"
+  ignore_unfixed:
+    description: "Ignore vulnerabilities for which a fix isn't available yet."
+    required: false
+    default: false
   label:
     description: "The label created in AccuKnox SaaS for associating scan results."
     required: true
@@ -66,7 +70,16 @@ runs:
 
     - name: Run AccuKnox Vulnerability Scanner
       run: |
-        $Scan image --severity ${{ inputs.severity }} -f json ${{ inputs.repository_name }}:${{ inputs.tag }} -o results.json --quiet
+        args=""
+        if [[ "${{ inputs.ignore_unfixed }}" == "true" ]]; then
+          args="$args --ignore-unfixed"
+        fi
+        $Scan image \
+          --severity ${{ inputs.severity }} \
+          -f json ${{ inputs.repository_name }}:${{ inputs.tag }} \
+          -o results.json \
+          --quiet \
+          "$args"
       env:
         Scan: trivy
       shell: bash
@@ -74,6 +87,7 @@ runs:
     - name: Print AccuKnox Results
       run: cat results.json
       shell: bash
+
     - name: Push report to CSPM panel
       run: |
         response=$(curl --location --request POST 'https://${{ inputs.endpoint }}/api/v1/artifact/?tenant_id=${{ inputs.tenant_id }}&data_type=TR&label_id=${{ inputs.label }}&save_to_s3=true' \
@@ -88,9 +102,18 @@ runs:
         fi
       shell: bash
 
-    - name: Run AccuKnox Vulnerability Scanner with specific tags
+    - name: Run AccuKnox Vulnerability Scanner with provided exit code
       run: |
-        $Scan image --exit-code ${{ inputs.exit_code }} --severity ${{ inputs.severity }} ${{ inputs.repository_name }}:${{ inputs.tag }} --quiet >/dev/null
+        args=""
+        if [[ "${{ inputs.ignore_unfixed }}" == "true" ]]; then
+          args="$args --ignore-unfixed"
+        fi
+        $Scan image \
+          --exit-code ${{ inputs.exit_code }} \
+          --severity ${{ inputs.severity }} \
+          ${{ inputs.repository_name }}:${{ inputs.tag }} \
+          --quiet \
+          "$args" >/dev/null
       env:
         Scan: trivy
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -62,16 +62,7 @@ runs:
 
     - name: Run AccuKnox Vulnerability Scanner
       run: |
-        args=""
-        if [[ "${{ inputs.ignore_unfixed }}" == "true" ]]; then
-          args="$args --ignore-unfixed"
-        fi
-        $Scan image \
-          --severity ${{ inputs.severity }} \
-          -f json ${{ inputs.repository_name }}:${{ inputs.tag }} \
-          -o results.json \
-          --quiet \
-          "$args"
+        $Scan image --severity ${{ inputs.severity }} -f json ${{ inputs.repository_name }}:${{ inputs.tag }} -o results.json --quiet
       env:
         Scan: trivy
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -2,10 +2,6 @@ name: AccuKnox Container Scan
 description: Scan Docker images using AccuKnox and push the results to the CSPM panel.
 
 inputs:
-  dockerfile_context:
-    description: "The context of the Dockerfile to use for building the image."
-    required: true
-    default: "Dockerfile"
   endpoint:
     description: "The URL of the CSPM panel to push the scan results to."
     required: true
@@ -48,7 +44,6 @@ runs:
         python validate_inputs.py
       shell: bash
       env:
-        DOCKERFILE_CONTEXT: ${{ inputs.dockerfile_context }}
         ENDPOINT: ${{ inputs.endpoint }}
         TOKEN: ${{ inputs.token }}
         TENANT_ID: ${{ inputs.tenant_id }}
@@ -56,10 +51,7 @@ runs:
         TAG: ${{ inputs.tag }}
         SEVERITY: ${{ inputs.severity }}
         CODE: ${{ inputs.exit_code }}
-    - name: Docker Build
-      run: |
-        docker build -t ${{ inputs.repository_name }}:${{ inputs.tag }} -f ${{ inputs.DOCKERFILE_CONTEXT }} .
-      shell: bash
+        IGNORE_UNFIXED: ${{ inputs.ignore_unfixed }}
 
     - name: Download Vulnerability Scanner
       run: |

--- a/action.yaml
+++ b/action.yaml
@@ -89,7 +89,7 @@ runs:
       run: |
         args=""
         if [[ "${{ inputs.ignore_unfixed }}" == "true" ]]; then
-          args="$args --ignore-unfixed"
+          args="--ignore-unfixed"
         fi
         $Scan image \
           --exit-code ${{ inputs.exit_code }} \

--- a/validate_inputs.py
+++ b/validate_inputs.py
@@ -24,6 +24,7 @@ def main():
         'TAG': os.getenv('TAG', ''),
         'SEVERITY': os.getenv('SEVERITY', ''),
         'CODE': os.getenv('CODE', '')
+        'IGNORE_UNFIXED': os.getenv('IGNORE_UNFIXED', ' '),
     }
 
 

--- a/validate_inputs.py
+++ b/validate_inputs.py
@@ -16,7 +16,6 @@ def validate_inputs(inputs):
 
 def main():
     inputs = {
-        'DOCKERFILE_CONTEXT': os.getenv('DOCKERFILE_CONTEXT', ''),
         'ENDPOINT': os.getenv('ENDPOINT', ''),
         'TOKEN': os.getenv('TOKEN', ''),
         'TENANT_ID': os.getenv('TENANT_ID', ''),


### PR DESCRIPTION
- `ignore_unfixed` param allows ignoring vulnerabilities for which a fix isn't available.
- This PR also removed the docker build step. We should allow callers to build the image themselves and pass in the image name and tag rather than dictating how the image should be built.