### PR TITLE
Fix SBOM issues: project name validation, keep_results, and upload_results support

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,10 @@ jobs:
           tag: "latest"
           severity: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
           soft_fail: true
-          upload_results: true  # set true if you want to upload result to Github artefact
-          generate_sbom: true   # set true to generate SBOM
-          project_name: ""      # must match the project name created in the dashboard
+          upload_results: true  # (Optional) set true if you want to upload result to Github artefact
+          generate_sbom: true   # (Optional) set true to generate SBOM
+          project_name: ""      # (Optional) must match the project name created in the dashboard
+          dockerfile_context: Dockerfile  # (Optional) Path to Dockerfile for building image before scan 
 ```
 
 ### ⚙️ Configuration Options (Inputs)
@@ -123,6 +124,7 @@ jobs:
 | `generate_sbom` | Generate and upload SBOM instead of vulnerability scan | ❌ No | `false` |
 | `project_name` | AccuKnox project name (required when SBOM generation is enabled) | ❌ No | — |
 | `upload_results` | Upload scan results as GitHub artifact | ❌ No | `false` |
+| `dockerfile_context` | Path to Dockerfile for building image before scan (locally) | ❌ No | — |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ jobs:
           image_name: "your-image"
           tag: "latest"
           severity: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
-          soft_fail: false
-          keep_results: true
+          soft_fail: true
+          upload_results: true  # set true if you want to upload result to Github artefact
           generate_sbom: true   # set true to generate SBOM
           project_name: ""      # must match the project name created in the dashboard
 ```
@@ -120,9 +120,9 @@ jobs:
 | `tag` | Tag of the container image | ❌ No | `latest` |
 | `severity` | Vulnerability severities to enforce (e.g., LOW, MEDIUM, HIGH, CRITICAL) | ❌ No | All |
 | `soft_fail` | Continue pipeline execution even if vulnerabilities are found | ❌ No | `false` |
-| `keep_results` | Retain scan result files after execution | ❌ No | `false` |
 | `generate_sbom` | Generate and upload SBOM instead of vulnerability scan | ❌ No | `false` |
 | `project_name` | AccuKnox project name (required when SBOM generation is enabled) | ❌ No | — |
+| `upload_results` | Upload scan results as GitHub artifact | ❌ No | `false` |
 
 ---
 

--- a/action.yaml
+++ b/action.yaml
@@ -6,6 +6,10 @@ branding:
   color: "purple"
 
 inputs:
+  dockerfile_context:
+    description: "The context of the Dockerfile to use for building the image (optional if image already exists)."
+    required: false
+    default: ""
   accuknox_token:
     description: "The token for authenticating with the CSPM panel."
     required: true
@@ -21,7 +25,7 @@ inputs:
   tag:
     description: "Docker image tag (optional)"
     required: false
-    default: ""
+    default: "latest"
   severity:
     description: "Comma-separated severities: UNKNOWN, LOW, MEDIUM, HIGH, CRITICAL"
     required: false
@@ -50,6 +54,13 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Docker Build (optional)
+      if: inputs.dockerfile_context != ''
+      run: |
+        echo "Building Docker image ${{ inputs.image_name }}:${{ inputs.tag }} from context ${{ inputs.dockerfile_context }}..."
+        docker build -t ${{ inputs.image_name }}:${{ inputs.tag }} -f ${{ inputs.dockerfile_context }} .
+      shell: bash
+
     - name: Run AccuKnox Container Scan
       shell: bash
       env:

--- a/action.yaml
+++ b/action.yaml
@@ -41,15 +41,18 @@ inputs:
   keep_results:
     description: "Keep scan results file after completion"
     required: false
+    default: true  
+  upload_results:
+    description: "Upload scan results as GitHub artifact"
+    required: false
     default: false
-
+  
 runs:
   using: "composite"
   steps:
     - name: Run AccuKnox Container Scan
       shell: bash
       env:
-        DEBUG: "TRUE" 
         ACCUKNOX_TOKEN: ${{ inputs.accuknox_token }}
         ACCUKNOX_LABEL: ${{ inputs.accuknox_label }}
         ACCUKNOX_ENDPOINT: ${{ inputs.accuknox_endpoint }}
@@ -59,7 +62,8 @@ runs:
         SOFT_FAIL: ${{ inputs.soft_fail }}
         GENERATE_SBOM: ${{ inputs.generate_sbom }}
         ACCUKNOX_PROJECT_NAME: ${{ inputs.project_name }}
-        KEEP_RESULTS: ${{ inputs.keep_results }}
+        KEEP_RESULTS: true
+        UPLOAD_RESULTS: ${{ inputs.upload_results }}
       run: |
         set -e
 
@@ -109,9 +113,9 @@ runs:
         fi
 
          # Build project name argument
-        PROJECT_NAME_ARG=""
+        PROJECT_NAME_ARGS=()
         if [ -n "$ACCUKNOX_PROJECT_NAME" ]; then
-          PROJECT_NAME_ARG="--project-name $ACCUKNOX_PROJECT_NAME"
+          PROJECT_NAME_ARGS=(--project-name "$ACCUKNOX_PROJECT_NAME")
         fi
 
         # Build scan command dynamically
@@ -122,6 +126,36 @@ runs:
         [ "$QUIET" = "true" ] && CMD_ARGS="$CMD_ARGS --quiet"
         
 
-        echo "Running AccuKnox container scan:"
-        echo "./accuknox-aspm-scanner scan $SOFT_FAIL_ARG $KEEP_RESULTS_ARG $PROJECT_NAME_ARG container --command \"$CMD\" --container-mode $GENERATE_SBOM_ARG"
-        ./accuknox-aspm-scanner scan $SOFT_FAIL_ARG $KEEP_RESULTS_ARG $PROJECT_NAME_ARG container --command "$CMD" --container-mode $GENERATE_SBOM_ARG
+        echo "Running AccuKnox vulnerability scan..."
+        ./accuknox-aspm-scanner scan \
+          $SOFT_FAIL_ARG \
+          $KEEP_RESULTS_ARG \
+          container \
+          --command "$CMD" \
+          --container-mode
+
+        cp results.json results-vuln.json
+ 
+        if [ "$GENERATE_SBOM" = "true" ]; then
+          echo "Running AccuKnox SBOM scan..."
+          ./accuknox-aspm-scanner scan \
+            $SOFT_FAIL_ARG \
+            $KEEP_RESULTS_ARG \
+            "${PROJECT_NAME_ARGS[@]}" \
+            container \
+            --command "$CMD" \
+            --container-mode \
+            --generate-sbom
+
+          cp results.json results-sbom.json
+          
+        fi
+
+    - name: Upload AccuKnox Scan Results
+      if: inputs.upload_results == 'true'
+      uses: actions/upload-artifact@v4
+      with:
+        name: accuknox-scan-results
+        path: |
+          results-*.json
+        retention-days: 15


### PR DESCRIPTION
### PR Description

This PR addresses the following bug tickets:

- **CNAPP-25023** – SBOM CI: Project name doesn’t support empty spaces  
  Updated project name handling to allow spaces, ensuring proper SBOM upload.

- **CNAPP-25024** – SBOM | container-scan-action: `keep_results` is useless  
  Updated action so `keep_results` is always true, simplifying scan result retention.

- **CNAPP-25073** – SBOM: `generate_sbom` flag should scan for vulnerabilities as well  
  Updated the scan logic so that enabling `generate_sbom` now also performs vulnerability scans.